### PR TITLE
Add turn On/Off features

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ Parameters:
     - int value between `1` (auto), `2` (low), `3` (medium), `4` (high)
 - `state:`
     - string value between `on` and `off`
+### SwitchBot Turn On
+
+Parameters:
+- `deviceId:`
+
+
+### SwitchBot Turn Off
+
+Parameters:
+- `deviceId:`
+
 
 ### SwitchBot Generic Command API Interface
 _For use this service read [here][generic-cmd-link]_
@@ -52,7 +63,7 @@ Parameters:
 - `deviceId:`
     - to get this id read [here][deviceid-link]
 - `command:`
-- `parameter:`
+- `parameter:` (optional)
 - `commandType:`
 
 

--- a/pyscript/apps/switchbot.py
+++ b/pyscript/apps/switchbot.py
@@ -98,7 +98,48 @@ fields:
     requestHelper(url,myjson,headers_dict)
 
 @service
-def switchbot_generic_command(deviceId, command, parameter, commandType):
+def switchbot_turn_on(deviceId=None):
+    """yaml
+name: SwitchBot Turn Device ON
+description: Turn Switchbot controlled device ON
+fields:
+  deviceId:
+    name: Device ID
+    description: Target deviceId
+    example: 00-000000000000-00000000
+    default:
+    required: true
+    selector:
+      text:
+    """
+    headers_dict=auth(**pyscript.app_config)
+    url=f"https://api.switch-bot.com/v1.1/devices/{deviceId}/commands"
+    myjson= {"command": "turnOn", "commandType": "command"}
+    requestHelper(url,myjson,headers_dict)
+
+@service
+def switchbot_turn_off(deviceId=None):
+    """yaml
+name: SwitchBot Turn Device OFF
+description: Turn Switchbot controlled device OFF
+fields:
+  deviceId:
+    name: Device ID
+    description: Target deviceId
+    example: 00-000000000000-00000000
+    default:
+    required: true
+    selector:
+      text:
+    """
+    headers_dict=auth(**pyscript.app_config)
+    url=f"https://api.switch-bot.com/v1.1/devices/{deviceId}/commands"
+    myjson= {"command": "turnOff", "commandType": "command"}
+    requestHelper(url,myjson,headers_dict)
+
+
+@service
+def switchbot_generic_command(deviceId=None, command=None, parameter=None, commandType=None):
     """yaml
 name: SwitchBot Generic Command API Interface
 description: This (py)script allows you to control all device in your "Switchbot Home" (refer to https://github.com/OpenWonderLabs/SwitchBotAPI)
@@ -116,7 +157,7 @@ fields:
     name: Command
     description: the name of the command
     example: turnOff
-    default: turnOff
+    default: 
     required: true
     selector:
       text:
@@ -124,9 +165,9 @@ fields:
   parameter:
     name: Parameters
     description: some commands require parameters, such as SetChannel
-    example: default
-    default: default
-    required: true
+    example: 
+    default: 
+    required: false
     selector:
       text:
 
@@ -137,12 +178,18 @@ fields:
     default: command
     required: true
     selector:
-      text:
+      select:
+        options:
+          - command
+          - customize
 
       """
     headers_dict=auth(**pyscript.app_config)
         
     url=f"https://api.switch-bot.com/v1.1/devices/{deviceId}/commands"
-    myjson= {"command": command,"parameter": parameter,"commandType": commandType}
+    myjson= {"command": command, "commandType": commandType}
+    if parameter is not None:
+      myjson["parameter"] = parameter
+
     requestHelper(url,myjson,headers_dict)
 


### PR DESCRIPTION
## Edits
- **Fix switchbot_generic_command**
   _The `Parameter` argument is optional and should not be required according to their documentation. That was confirmed during testing._
- **Add `switchbot_turn_on` & `switchbot_turn_off`**
   _Every device support at least the `turnOn` and `turnOff` commands according to the API documentation, therefore it makes sense to add a dedicated service for those._
   
- **Update ReadMe**
  _Reflect the additions and fixes._

I tested this code on my setup and the command could be executed on my devices. It was tested on a IR light and IR Projector.