### PR TITLE
add service switchbot_ir_light_control

### DIFF
--- a/pyscript/apps/switchbot.py
+++ b/pyscript/apps/switchbot.py
@@ -218,7 +218,7 @@ fields:
           - turnOff
           - brightnessUp
           - brightnessDown
-        mode: list
+        mode: dropdown
     """
     device_id = extract_device_id(device)
     headers = auth(**pyscript.app_config)

--- a/pyscript/apps/switchbot.py
+++ b/pyscript/apps/switchbot.py
@@ -191,6 +191,40 @@ fields:
     command_execute(headers_dict, deviceId, 'setAll', parameter=f"{temperature},{mode},{fan_speed},{state}")
 
 @service
+def switchbot_ir_light_control(device=None, command=None):
+    """yaml
+name: SwitchBot IR light control
+description: Send command via infrared to light device.
+fields:
+  device:
+    name: Device
+    description: Target device
+    example: switch.switchbot_remote_light
+    default:
+    required: true
+    selector:
+      entity:
+        domain: switch
+  command:
+    name: Command
+    description: the name of the command
+    example: turnOff
+    default: 
+    required: true
+    selector:
+      select:
+        options:
+          - turnOn
+          - turnOff
+          - brightnessUp
+          - brightnessDown
+        mode: list
+    """
+    device_id = extract_device_id(device)
+    headers = auth(**pyscript.app_config)
+    command_execute(headers, device_id, command)
+
+@service
 def switchbot_turn_on(device=None):
 
     """yaml


### PR DESCRIPTION
Add switchbot_ir_light_control service  #5  
Options are:
 - turnOn
 - turnOff
 - BrightnessUp
 - BrightnessDown

Unfortunately, the API doesn't allow us other commands for IR lights. ([doc](https://github.com/OpenWonderLabs/SwitchBotAPI#command-set-for-virtual-infrared-remote-devices))

The function is simple but the magic is in the docstring which generate the template for home assistant
