### PR TITLE
Add support for non IR devices: Bot, Contact Sensor, Curtain and Meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ _Create Home Assistant `switch` entity for each IR Device and Bot connected to y
 _Create Home Assistant `cover` entity for each Curtain, `binary_sensor` entity for each Contact Sensor and `sensor` entity for each Meter connected to your Switchbot Hub. These devices are stored as `<entity_type>.switchbot_remote_<device_name>` eg `cover.switchbot_remote_bedroom_curtains`_
 
 _`<device_name>` corresponds to the name of the device in the SwitchBot app._  
-_if `<device_name>` doesn't contains Alphanum characters (e.g is written in another alphabet), it is replaced by `<deviceType>_<deviceId[-4:]>` (e.g. `switch.switchbot_remote_light_0D62`)_  
+_If `<device_name>` doesn't contains Alphanum characters (e.g is written in another alphabet), it is replaced by `<deviceType>_<deviceId[-4:]>` (e.g. `switch.switchbot_remote_light_0D62`)_  
 _The entities can then be used for sending commands or getting status using other functions of this pyscript. ⚠️ Not working stand alone ⚠️_
 _In case the device doesn't exist in the future, you will be notified on your devices._
 
@@ -187,9 +187,13 @@ _Interface for Curtain (turnOn, turnOff, setPosition)_
 _Gets the state of a Switchbot binary sensor (on, off)._
 Runs every five minutes generating 288 API calls per sensor per day.
 
+Parameters: ***None***
+
 ### 🔸Switchbot Meter Sensor
 _Gets the state of a Switchbot Meter (temperature, humidity)._
 Runs every five minutes generating 288 API calls per meter per day.
+
+Parameters: ***None***
 
 
 ## Work in Progress

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more info click [here][switchbot-api-repo]
     - [Light](#switchbot-ir-light-control)
     - [Generic Command](#switchbot-generic-command-api-interface)
     - [Curtain](#switchbot-curtain-control)
-    - [Get Status](#switchbot-get status)
+    - [Get Status](#switchbot-get-status)
 - [Work in Progress](#work-in-progress)
 - [Changelog](#changelog)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ For more info click [here][switchbot-api-repo]
     - [HVAC](#switchbot-hvac-api-interface)
     - [Light](#switchbot-ir-light-control)
     - [Generic Command](#switchbot-generic-command-api-interface)
+    - Switchbot Curtain Control
+    - Switchbot Binary Sensor
+    - Switchbot Meter Sensor
 - [Work in Progress](#work-in-progress)
 - [Changelog](#changelog)
 
@@ -33,7 +36,7 @@ For more info click [here][switchbot-api-repo]
    cd /config
    git clone https://github.com/SiriosDev/SwitchBot-API-Script-Caller.git
    ```
-2. **Check if you have a `pyscript/config.yaml` file. If not, create one and then add the following in your main top-level configuration.yaml file.
+2. **Check if you have a `pyscript/config.yaml` file. If not, create one and then add the following in your main top-level configuration.yaml file.**
     ``` yaml
     pyscript: !include pyscript/config.yaml
     ```
@@ -104,10 +107,11 @@ It is important to execute [`SwitchBot Refresh Devices`](#switchbot-refresh-devi
 - [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)]
 
 ### 🔸SwitchBot Refresh Devices
-_Create Home Assistant `switch` entity for each IR Device connected with your SwitchBot Hubs. Devices are stored as `switch.switchbot_remote_<device_name>`._  
+_Create Home Assistant `switch` entity for each IR Device and Bot connected to your SwitchBot Hub. IR devices and Bots are stored as `switch.switchbot_remote_<device_name>`._  
+_Create Home Assistant `cover` entity for each Curtain, `binary_sensor` entity for each Contact Sensor and `sensor` entity for each Meter connected to your Switchbot Hub. These devices are stored as `<entity_type>.switchbot_remote_<device_name>` eg `cover.switchbot_remote_bedroom_curtains`_
 _`<device_name>` correspond to the name of the device in the SwitchBot app._  
 _if `<device_name>` doesn't contains Alphanum characters (e.g is written in another alphabet), it is replaced by `<deviceType>_<deviceId[-4:]>` (e.g. `switch.switchbot_remote_light_0D62`)_  
-_The entities can then be used for sending commands using other functions of this pyscript. ⚠️ Not working stand alone ⚠️_
+_The entities can then be used for sending commands or getting status using other functions of this pyscript. ⚠️ Not working stand alone ⚠️_
 _In case the device doesn't exist in the future, you will be notified on your devices._
 
 Parameters: ***None***
@@ -193,6 +197,15 @@ For any problems open an Issue, (soon I will insert a template for that).
 
 
 ## Changelog
+### <Release date> v? (🟢 New Features)
+** Added support for non-IR devices** : Bot, Contact Sensor, Curtain and Meter
+
+** Add service 'Switchbot Curtains Command'** : Send command to Curtain device.
+
+** Add time trigger to get the status of binary sensors every 5 minutes.
+
+** Add times trigger to get the status of Meter every 5 minutes.
+
 ### 2023.01.16 v0.2.0 (🟢 New Features and 🛠️ some fixes)
 **Add service `SwitchBot IR Light Control`** : Send command via infrared to light device.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ For more info click [here][switchbot-api-repo]
     - [HVAC](#switchbot-hvac-api-interface)
     - [Light](#switchbot-ir-light-control)
     - [Generic Command](#switchbot-generic-command-api-interface)
-    - Switchbot Curtain Control
-    - Switchbot Binary Sensor
-    - Switchbot Meter Sensor
+    - [Switchbot Curtain Control](#switchbot-curtain-control)
+    - [Switchbot Binary Sensor](#switchbot-binary-sensor-eg-contact-sensor)
+    - [Switchbot Meter Sensor](#switchbot-meter-sensor)
 - [Work in Progress](#work-in-progress)
 - [Changelog](#changelog)
 
@@ -102,14 +102,15 @@ It is important to execute [`SwitchBot Refresh Devices`](#switchbot-refresh-devi
 - [SwitchBot IR HVAC Control (`pyscript.switchbot_hvac`)](#switchbot-hvac-api-interface)
 - [SwitchBot IR Light Control (`pyscript.switchbot_ir_light_control`)](#switchbot-ir-light-control)
 - [SwitchBot Generic Command (`pyscript.switchbot_generic_command`)](#switchbot-generic-command-api-interface)
-- [SwitchBot Curtain Command (`pyscript.switchbot_curtain_command`)]
-- [SwitchBot Binary Sensor Status (`pyscript.switchbot_binary_sensor_status`)]
-- [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)]
+- [SwitchBot Curtain Command (`pyscript.switchbot_curtain_command`)](#switchbot-curtain-control)
+- [SwitchBot Binary Sensor Status (`pyscript.switchbot_binary_sensor_status`)](#switchbot-binary-sensor-eg-contact-sensor)
+- [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)](#switchbot-meter-sensor)
 
 ### 🔸SwitchBot Refresh Devices
 _Create Home Assistant `switch` entity for each IR Device and Bot connected to your SwitchBot Hub. IR devices and Bots are stored as `switch.switchbot_remote_<device_name>`._  
 _Create Home Assistant `cover` entity for each Curtain, `binary_sensor` entity for each Contact Sensor and `sensor` entity for each Meter connected to your Switchbot Hub. These devices are stored as `<entity_type>.switchbot_remote_<device_name>` eg `cover.switchbot_remote_bedroom_curtains`_
-_`<device_name>` correspond to the name of the device in the SwitchBot app._  
+
+_`<device_name>` corresponds to the name of the device in the SwitchBot app._  
 _if `<device_name>` doesn't contains Alphanum characters (e.g is written in another alphabet), it is replaced by `<deviceType>_<deviceId[-4:]>` (e.g. `switch.switchbot_remote_light_0D62`)_  
 _The entities can then be used for sending commands or getting status using other functions of this pyscript. ⚠️ Not working stand alone ⚠️_
 _In case the device doesn't exist in the future, you will be notified on your devices._
@@ -180,14 +181,14 @@ _Interface for Curtain (turnOn, turnOff, setPosition)_
 - `command:`
     - string value between `turnOn`, `turnOff`, `setPosition`
 - `parameter:` (optional)
-    - string giving the position for the setPosition command. (See the [SwitchbotAPI Curtain command][https://github.com/OpenWonderLabs/SwitchBotAPI#curtain-2].)
+    - string giving the position for the setPosition command. (See the [SwitchbotAPI Curtain command]([url](https://github.com/OpenWonderLabs/SwitchBotAPI#curtain-2)).)
     
 ### 🔸Switchbot Binary Sensor (eg Contact Sensor)
-_Gets the state of a Switchbot binary sensor (on, off)_
+_Gets the state of a Switchbot binary sensor (on, off)._
 Runs every five minutes generating 288 API calls per sensor per day.
 
 ### 🔸Switchbot Meter Sensor
-_Gets the state of a Switchbot Meter (temperature, humidity)_
+_Gets the state of a Switchbot Meter (temperature, humidity)._
 Runs every five minutes generating 288 API calls per meter per day.
 
 
@@ -198,13 +199,13 @@ For any problems open an Issue, (soon I will insert a template for that).
 
 ## Changelog
 ### <Release date> v? (🟢 New Features)
-** Added support for non-IR devices** : Bot, Contact Sensor, Curtain and Meter
+**Add support for non-IR devices** : Bot, Contact Sensor, Curtain and Meter.**
 
-** Add service 'Switchbot Curtains Command'** : Send command to Curtain device.
+**Add service 'Switchbot Curtains Command'** : Send command to Curtain device.**
 
-** Add time trigger to get the status of binary sensors every 5 minutes.
+**Add time trigger to get the status of binary sensors every 5 minutes.**
 
-** Add times trigger to get the status of Meter every 5 minutes.
+**Add time trigger to get the status of Meter every 5 minutes.**
 
 ### 2023.01.16 v0.2.0 (🟢 New Features and 🛠️ some fixes)
 **Add service `SwitchBot IR Light Control`** : Send command via infrared to light device.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ For more info click [here][switchbot-api-repo]
     - [Light](#switchbot-ir-light-control)
     - [Generic Command](#switchbot-generic-command-api-interface)
     - [Curtain](#switchbot-curtain-control)
-    - [Binary Sensor](#switchbot-binary-sensor-eg-contact-sensor)
-    - [Meter](#switchbot-meter-sensor)
+    - [Get Status](#switchbot-get status)
 - [Work in Progress](#work-in-progress)
 - [Changelog](#changelog)
 
@@ -103,8 +102,7 @@ It is important to execute [`SwitchBot Refresh Devices`](#switchbot-refresh-devi
 - [SwitchBot IR Light Control (`pyscript.switchbot_ir_light_control`)](#switchbot-ir-light-control)
 - [SwitchBot Generic Command (`pyscript.switchbot_generic_command`)](#switchbot-generic-command-api-interface)
 - [SwitchBot Curtain Command (`pyscript.switchbot_curtain_command`)](#switchbot-curtain-control)
-- [SwitchBot Binary Sensor Status (`pyscript.switchbot_binary_sensor_status`)](#switchbot-binary-sensor-eg-contact-sensor)
-- [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)](#switchbot-meter-sensor)
+- [SwitchBot Get Status (`pyscript.switchbot_get_status`)](#switchbot-get-status)
 
 ### 🔸SwitchBot Refresh Devices
 _Creates Home Assistant `switch` entity for each IR Device and Bot connected to your SwitchBot Hub. IR devices and Bots are stored as `switch.switchbot_remote_<device_name>`._  
@@ -183,15 +181,9 @@ _Interface for Curtain (turnOn, turnOff, setPosition)_
 - `parameter:` (optional)
     - string giving the position for the setPosition command. (See the [SwitchbotAPI Curtain command]([url](https://github.com/OpenWonderLabs/SwitchBotAPI#curtain-2)).)
     
-### 🔸Switchbot Binary Sensor (eg Contact Sensor)
-_Gets the state of a Switchbot binary sensor (on, off)._
-Runs every five minutes generating 288 API calls per sensor per day.
-
-Parameters: ***None***
-
-### 🔸Switchbot Meter Sensor
-_Gets the state of a Switchbot Meter (temperature, humidity)._
-Runs every five minutes generating 288 API calls per meter per day.
+### 🔸Switchbot Get Status
+_Gets the state of Switchbot Bots, Contact Sensors, Curtains and Meters._
+Runs every five minutes generating 288 API calls per sensor per day. Switchbot limits API calls to 10,000 per day. So, this limits the number of devices to 34 (excluding IR devices.) See the [SwitchbotAPI API]([url](https://github.com/OpenWonderLabs/SwitchBotAPI#get-device-status)) for the data returned from a status call.
 
 Parameters: ***None***
 
@@ -203,13 +195,13 @@ For any problems open an Issue, (soon I will insert a template for that).
 
 ## Changelog
 ### <Release date> v? (🟢 New Features)
-**Add support for non-IR devices** : Bot, Contact Sensor, Curtain and Meter.**
+**Add support for non-IR devices** : Bot, Contact Sensor, Curtain and Meter.
 
-**Add service 'Switchbot Curtains Command'** : Send command to Curtain device.**
+**Add service 'Switchbot Curtains Command'** : Send command to Curtain device.
 
-**Add time trigger to get the status of binary sensors every 5 minutes.**
+**Add time trigger to get the status of Bots, Contact Sensors, Curtains and Meters every 5 minutes.** This will show in the Logbook even if you only have IR devices. However, the API calls will only be made for non-IR devices.
 
-**Add time trigger to get the status of Meter every 5 minutes.**
+**Add time trigger to run 'Refresh Devices' at startup.**
 
 ### 2023.01.16 v0.2.0 (🟢 New Features and 🛠️ some fixes)
 **Add service `SwitchBot IR Light Control`** : Send command via infrared to light device.

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ It is important to execute [`SwitchBot Refresh Devices`](#switchbot-refresh-devi
 - [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)](#switchbot-meter-sensor)
 
 ### 🔸SwitchBot Refresh Devices
-_Create Home Assistant `switch` entity for each IR Device and Bot connected to your SwitchBot Hub. IR devices and Bots are stored as `switch.switchbot_remote_<device_name>`._  
-_Create Home Assistant `cover` entity for each Curtain, `binary_sensor` entity for each Contact Sensor and `sensor` entity for each Meter connected to your Switchbot Hub. These devices are stored as `<entity_type>.switchbot_remote_<device_name>` eg `cover.switchbot_remote_bedroom_curtains`_
+_Creates Home Assistant `switch` entity for each IR Device and Bot connected to your SwitchBot Hub. IR devices and Bots are stored as `switch.switchbot_remote_<device_name>`._  
+_Creates Home Assistant `cover` entity for each Curtain, `binary_sensor` entity for each Contact Sensor and `sensor` entity for each Meter connected to your Switchbot Hub. These devices are stored as `<entity_type>.switchbot_remote_<device_name>` eg `cover.switchbot_remote_bedroom_curtains`_
 
 _`<device_name>` corresponds to the name of the device in the SwitchBot app._  
 _If `<device_name>` doesn't contains Alphanum characters (e.g is written in another alphabet), it is replaced by `<deviceType>_<deviceId[-4:]>` (e.g. `switch.switchbot_remote_light_0D62`)_  

--- a/README.md
+++ b/README.md
@@ -33,7 +33,11 @@ For more info click [here][switchbot-api-repo]
    cd /config
    git clone https://github.com/SiriosDev/SwitchBot-API-Script-Caller.git
    ```
-2. **Include [`pyscript/switchbot.yaml`](./pyscript/switchbot.yaml) in your `pyscript/config.yaml` under the `switchbot` section**
+2. **Check if you have a `pyscript/config.yaml` file. If not, create one and then add the following in your main top-level configuration.yaml file.
+    ``` yaml
+    pyscript: !include pyscript/config.yaml
+    ```
+3. **Include [`pyscript/switchbot.yaml`](./pyscript/switchbot.yaml) in your `pyscript/config.yaml` under the `switchbot` section**
    ```yaml
    # /config/pyscript/config.yaml
    allow_all_imports: true
@@ -43,7 +47,7 @@ For more info click [here][switchbot-api-repo]
     switchbot: !include /config/SwitchBot-API-Script-Caller/pyscript/switchbot.yaml
    # (...)
    ```
-3. **Set the authentication secrets in `secrets.yaml` homeassistant file**
+4. **Set the authentication secrets in `secrets.yaml` homeassistant file**
     - Random Value (`switchbot_nonc`) (I suggest using an UUID generator, but any unique alphanumeric string is fine)
     ```yaml
     # secrets.yaml
@@ -54,7 +58,7 @@ For more info click [here][switchbot-api-repo]
     # Random Value: you can use a UUID generator, but any unique alphanumeric string is OK
     switchbot_nonc: xxxxxxxxxx
     ```
-4. **Link the files in the `pyscript` directory**
+5. **Link the files in the `pyscript` directory**
    ```sh
    # use `mkdir -p /config/pyscript/apps/` if the directory doesn't exist
    cd /config/pyscript/apps/
@@ -70,7 +74,7 @@ cd SwitchBot-API-Script-Caller
 git pull
 ```
 ⚠️ **See changelog before updating.**  
-The project is still in developpement and breaking changes may occurs.
+The project is still in development and breaking changes may occurs.
 
 ### Installation Notes
 - In order to see the `Developper options` in the Switchbot app (version ≥6.14), click repetively on the version number in the App's settings.
@@ -95,6 +99,9 @@ It is important to execute [`SwitchBot Refresh Devices`](#switchbot-refresh-devi
 - [SwitchBot IR HVAC Control (`pyscript.switchbot_hvac`)](#switchbot-hvac-api-interface)
 - [SwitchBot IR Light Control (`pyscript.switchbot_ir_light_control`)](#switchbot-ir-light-control)
 - [SwitchBot Generic Command (`pyscript.switchbot_generic_command`)](#switchbot-generic-command-api-interface)
+- [SwitchBot Curtain Command (`pyscript.switchbot_curtain_command`)]
+- [SwitchBot Binary Sensor Status (`pyscript.switchbot_binary_sensor_status`)]
+- [SwitchBot Meter Sensor Status (`pyscript.switchbot_meter_sensor_status`)]
 
 ### 🔸SwitchBot Refresh Devices
 _Create Home Assistant `switch` entity for each IR Device connected with your SwitchBot Hubs. Devices are stored as `switch.switchbot_remote_<device_name>`._  
@@ -154,13 +161,30 @@ _Allows you to send any request to the API. (See [documentation][generic-cmd-lin
 - `device`
     - See [`SwitchBot Refresh Devices`](#switchbot-refresh-devices).
 - `command:`
-    - One of the command supported by the device. (see [documentation][generic-cmd-link])
+    - One of the commands supported by the device. (see [documentation][generic-cmd-link])
 - `parameter:` (optional)
     - Parameter for the command, if required (e.g. `SetChannel`)
     - use `default` if not used
 - `commandType:`
     - `command` for standard commands
     - `customize` for custom commands
+
+### 🔸Switchbot Curtain Control
+_Interface for Curtain (turnOn, turnOff, setPosition)_
+- `device`
+    - See [`SwitchBot Refresh Devices`](#switchbot-refresh-devices).
+- `command:`
+    - string value between `turnOn`, `turnOff`, `setPosition`
+- `parameter:` (optional)
+    - string giving the position for the setPosition command. (See the [SwitchbotAPI Curtain command][https://github.com/OpenWonderLabs/SwitchBotAPI#curtain-2].)
+    
+### 🔸Switchbot Binary Sensor (eg Contact Sensor)
+_Gets the state of a Switchbot binary sensor (on, off)_
+Runs every five minutes generating 288 API calls per sensor per day.
+
+### 🔸Switchbot Meter Sensor
+_Gets the state of a Switchbot Meter (temperature, humidity)_
+Runs every five minutes generating 288 API calls per meter per day.
 
 
 ## Work in Progress

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ For more info click [here][switchbot-api-repo]
     - [HVAC](#switchbot-hvac-api-interface)
     - [Light](#switchbot-ir-light-control)
     - [Generic Command](#switchbot-generic-command-api-interface)
-    - [Switchbot Curtain Control](#switchbot-curtain-control)
-    - [Switchbot Binary Sensor](#switchbot-binary-sensor-eg-contact-sensor)
-    - [Switchbot Meter Sensor](#switchbot-meter-sensor)
+    - [Curtain](#switchbot-curtain-control)
+    - [Binary Sensor](#switchbot-binary-sensor-eg-contact-sensor)
+    - [Meter](#switchbot-meter-sensor)
 - [Work in Progress](#work-in-progress)
 - [Changelog](#changelog)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ git pull
 The project is still in development and breaking changes may occurs.
 
 ### Installation Notes
-- In order to see the `Developper options` in the Switchbot app (version ≥6.14), click repetively on the version number in the App's settings.
+- In order to see the `Developer options` in the Switchbot app (version ≥6.14), click repetively on the version number in the App's settings.
     <details>
     <summary>Click her for detailed procedure</summary>
   

--- a/pyscript/apps/switchbot.py
+++ b/pyscript/apps/switchbot.py
@@ -120,7 +120,7 @@ def create_non_ir_entities(devices):
       non_ir['friendly_name'] = gen_dev_name(non_ir)
       non_ir['icon'] = gen_icon(non_ir)
       state.set(f'{gen_non_ir_uid(non_ir)}', value=non_ir.get(KEY_DEV_ID), new_attributes=non_ir)
-  switchbot_time_trigger() # Get an initial status for sensor-like devices.
+  switchbot_get_status() # Get an initial status for sensor-like devices.
 
 
 @pyscript_executor
@@ -435,7 +435,7 @@ fields:
 # Status checking
 # Status requests got every 5 minutes (288 API calls / device / day).
 @time_trigger("period(0:00, 300 sec)")
-def switchbot_time_trigger():
+def switchbot_get_status():
   states = state.names()
   for s in states:
     if (PREFIX in s):


### PR DESCRIPTION
Add support for non-IR devices : Bot, Contact Sensor, Curtain and Meter.

Add service 'Switchbot Curtains Command' : Send command to Curtain device.

Add time trigger to get the status of Bots, Contact Sensors, Curtains and Meters every 5 minutes. This will show in the Logbook even if you only have IR devices. However, the API calls will only be made for non-IR devices.

Add time trigger to run 'Refresh Devices' at startup.

I've successfully tested this with my Switchbot devices: Bot, Contact Sensor, Curtain and Meter. I do not have any IR devices.